### PR TITLE
일회용 셀 업데이트 수정

### DIFF
--- a/src/main/java/f_thon/godlifebingo/core/cell/Cell.java
+++ b/src/main/java/f_thon/godlifebingo/core/cell/Cell.java
@@ -28,12 +28,24 @@ public class Cell extends BaseEntity {
     @JoinColumn(name = "godlife_id")
     private GodLife godlife;
 
-    public void updateProgress() {
-        this.currentProgress++;
+    public void updateProgress(Bingo bingo, GodLife godLife) {
+        int totalCount = bingo.getTotalCount();
+        boolean isOneOff = godLife.isOneOff();
+        if (isOneOff) {
+            this.currentProgress += totalCount;
+        } else {
+            this.currentProgress++;
+        }
     }
 
-    public void rollbackProgress() {
-        this.currentProgress--;
+    public void rollbackProgress(Bingo bingo, GodLife godLife) {
+        int totalCount = bingo.getTotalCount();
+        boolean isOneOff = godLife.isOneOff();
+        if (isOneOff) {
+            this.currentProgress -= totalCount;
+        } else {
+            this.currentProgress--;
+        }
     }
     public void setClicked(boolean isClicked){
         this.isClicked = isClicked;

--- a/src/main/java/f_thon/godlifebingo/core/cell/CellRepository.java
+++ b/src/main/java/f_thon/godlifebingo/core/cell/CellRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface CellRepository extends JpaRepository<Cell, Long> {
 
-    @EntityGraph(attributePaths = "bingo")
+    @EntityGraph(attributePaths = {"bingo", "godlife"})
     Optional<Cell> findById(Long cellId);
 
     @EntityGraph(attributePaths = "godlife")


### PR DESCRIPTION
* 일회용 셀은 업데이트, 롤백시 모든 진행도가 변경된다.

* 빙고의 수행 기간이 7일일때, 
* 일회용 셀이 아닌 아침 6시 기상 => 한번 업데이트시 진행도 + 1,
* 일회용 셀 ex) 만보 걷기 => 한번 업데이트시 진행도 + 7